### PR TITLE
Add version field to ArchivalDiskFile struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "atoi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3014,7 +3014,7 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wipac_datamove"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 [package]
 name = "wipac_datamove"
 authors = ["Patrick Meade <pmeade@icecube.wisc.edu>"]
-version = "0.6.0"
+version = "0.6.1"
 repository = "https://github.com/WIPACrepo/datamove"
 description = "Modern data movement components"
 edition = "2021"

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -129,7 +129,6 @@ pub struct ArchivalDiskFile {
     //       Note, it's also in the JADE database and the file pair archive.
     // #[serde(rename = "xmlMetadata")]
     // pub xml_metadata: String,
-
     /// the version of the ArchivalDiskFile metadata schema
     /// if you need more than 2 billion metadata schema versions,
     /// https://knowyourmeme.com/memes/stop-it-get-some-help

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -131,7 +131,7 @@ pub struct ArchivalDiskFile {
     // pub xml_metadata: String,
     /// the version of the ArchivalDiskFile metadata schema
     /// if you need more than 2 billion metadata schema versions,
-    /// https://knowyourmeme.com/memes/stop-it-get-some-help
+    /// <https://knowyourmeme.com/memes/stop-it-get-some-help>
     #[serde(rename = "version")]
     pub version: i32,
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::sps::jade_db::service::disk::JadeDisk;
 
+/// the current version of the schema describing the metadata of an ArchivalDiskFile
+pub const ARCHIVAL_DISK_FILE_METADATA_SCHEMA_VERSION: i32 = 2;
+
 /// metadata for an archival disk
 #[derive(Clone, Deserialize, Serialize)]
 pub struct ArchivalDiskMetadata {
@@ -126,4 +129,10 @@ pub struct ArchivalDiskFile {
     //       Note, it's also in the JADE database and the file pair archive.
     // #[serde(rename = "xmlMetadata")]
     // pub xml_metadata: String,
+
+    /// the version of the ArchivalDiskFile metadata schema
+    /// if you need more than 2 billion metadata schema versions,
+    /// https://knowyourmeme.com/memes/stop-it-get-some-help
+    #[serde(rename = "version")]
+    pub version: i32,
 }

--- a/src/sps/process/disk_archiver.rs
+++ b/src/sps/process/disk_archiver.rs
@@ -18,7 +18,7 @@ use crate::config::{
     load_contacts, load_data_streams, load_disk_archives, Contacts, DataStream, DataStreams,
     DiskArchive, DiskArchives,
 };
-use crate::metadata::{ArchivalDiskFile, ArchivalDiskMetadata};
+use crate::metadata::{ARCHIVAL_DISK_FILE_METADATA_SCHEMA_VERSION, ArchivalDiskFile, ArchivalDiskMetadata};
 use crate::sps::email::{
     comma_separated_filter, compile_templates, send_email_disk_full, send_email_disk_started,
 };
@@ -1130,6 +1130,7 @@ pub async fn create_archival_disk_file(
             .jade_file_pair_uuid
             .clone()
             .expect("jade_file_pair.uuid IS null"),
+        version: ARCHIVAL_DISK_FILE_METADATA_SCHEMA_VERSION,
     }
 }
 

--- a/src/sps/process/disk_archiver.rs
+++ b/src/sps/process/disk_archiver.rs
@@ -18,7 +18,9 @@ use crate::config::{
     load_contacts, load_data_streams, load_disk_archives, Contacts, DataStream, DataStreams,
     DiskArchive, DiskArchives,
 };
-use crate::metadata::{ARCHIVAL_DISK_FILE_METADATA_SCHEMA_VERSION, ArchivalDiskFile, ArchivalDiskMetadata};
+use crate::metadata::{
+    ArchivalDiskFile, ArchivalDiskMetadata, ARCHIVAL_DISK_FILE_METADATA_SCHEMA_VERSION,
+};
 use crate::sps::email::{
     comma_separated_filter, compile_templates, send_email_disk_full, send_email_disk_started,
 };


### PR DESCRIPTION
Adds a `version` field to the metadata recorded for each file on JADE archival disks.

This lets us determine (programmatically) if the field containing a Data Stream UUID is reliable or not.

Overall: `version` is just good meta-metadata to keep around; you never regret knowing your schema.
